### PR TITLE
grid layout finished #24

### DIFF
--- a/src/lib/ErrorResult.svelte
+++ b/src/lib/ErrorResult.svelte
@@ -2,8 +2,18 @@
     export let data;
 </script>
 
-<p>Test ErrorResult</p>
+<li></li>
+<li></li>
+<li></li>
+<li></li>
+<li></li>
 
 <style>
-    
+    li{
+        height: 20%;
+        background-color: var(--color-background-section);
+        border-radius: 8px;
+        box-shadow: 0px 0px 9px -2px var(--color-black);
+        list-style: none;
+    }
 </style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,23 +3,23 @@
 
 </script>
 
-<header>
+<header class="wrapper header-layout">
 
 </header>
 
-<main>
-  <section>
+<main class="wrapper main-layout">
+  <section class="auto">
     <AutomaticScan />
   </section>
-  <ul>
+  <ul class="error">
     <ErrorResult />
   </ul>
 
-  <section>
+  <section class="type">
     <TypeGraph />
   </section>
 
-  <section>
+  <section class="accessibillity">
     <AccessibillityGraph />
   </section>
 </main>
@@ -28,4 +28,49 @@
 </footer>
 
 <style>
+ .wrapper{
+    margin: auto;
+    width: 1100px;
+ }
+
+ .header-layout{
+  height: 10%;
+ }
+
+ .main-layout{
+  display: grid;
+  grid-template-columns: 2.2fr 0.8fr; 
+  grid-template-rows: 1fr 1fr 1.2fr;   
+  gap: 20px;  
+  height: 90%;
+  margin: 20px auto;
+ }
+
+ section{
+  background-color: var(--color-background-section);
+  border-radius: 8px;
+  box-shadow: 0px 0px 9px -2px var(--color-black);
+ }
+
+ .auto{
+  grid-area: 1 / 1 / 2 / 2;       
+ }
+
+ .error{
+  grid-area: 1 / 2 / 3 / 3;   
+  display: flex;
+  flex-direction: column; 
+  row-gap: 20px;
+ }
+
+ .type{
+  grid-area: 2 / 1 / 3 / 2;     
+ }
+
+ .accessibillity{
+  grid-area: 3 / 1 / 4 / 3;
+ }
+
+
+ 
 </style>


### PR DESCRIPTION
**wat heb ik gemaakt/gedaan**

heb een skelet met een grid layout in de main page.svelte aangemaakt ( issue #24  )

Met deze grid die ik eraan heb toegevoegd heb ik ervoor gezorgd dat alle section overeen komen met het ontwerp

daarnaast heb ik in `ErrorResult.svelte` even wat li'tjes heb toegevoegd om die ook te stylen volgens het ontwerp

**dit is hoe het eruit ziet**
![layo](https://github.com/user-attachments/assets/a4ffb53e-7bcb-4b63-a490-a97a69bde552)

**dingen die mogelijk veranderd gaan worden**

hoogswaarschijnlijk moet na de merge alleen nog wat vernaderd worden aan de height van de `main-layout & .header-layout`

ook de gap property moet nog een var krijgen. heb tot nu toe alleen 20px er in gezet