### PR TITLE
`ErrorResult.svelte` stijlen 

### DIFF
--- a/src/lib/ErrorResult.svelte
+++ b/src/lib/ErrorResult.svelte
@@ -76,7 +76,7 @@
 
   li h3 {
     padding-bottom: 0.5em;
-    font-size: 20px;
+    font-size: 1em;
   }
 
   li div {

--- a/src/lib/ErrorResult.svelte
+++ b/src/lib/ErrorResult.svelte
@@ -68,6 +68,10 @@
     box-shadow: var(--box-shadow);
     list-style: none;
     padding: var(--average-padding);
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
   }
 
   li h3 {


### PR DESCRIPTION

> Dit gaat over de issue #73, daar kan je meer vinden

# Bewerking
Hier kan je precies zien wat ik heb bijgewerkt aan het component `ErrorResult.svelte`. Hier kan je zien dat ik iets aan de heading heb gedaan en dat het meer is gecentreerd

## Before
![image](https://github.com/user-attachments/assets/2837f713-1c9a-4e26-8a80-6ac73c13b0e8)

## After
![image](https://github.com/user-attachments/assets/6b91d2b2-c377-4d6f-b7b8-f06040cec0e6)

# Notes
Ik moest de `main` branch mergen en er waren een aantal conflicten, maar volgens mij is dat verholpen
